### PR TITLE
Article Image Reloading Fix

### DIFF
--- a/app/src/main/java/com/taboola/hp4udemoapplication/view/MainActivity.kt
+++ b/app/src/main/java/com/taboola/hp4udemoapplication/view/MainActivity.kt
@@ -19,9 +19,9 @@ class MainActivity : AppCompatActivity() {
             it.setDisplayShowHomeEnabled(true)
         }
 
-        val mem: Int = Runtime.getRuntime().maxMemory().toInt()
+        val maximumMemorySizeForLruCache: Int = Runtime.getRuntime().maxMemory().toInt()
         picasso = Picasso.Builder(applicationContext)
-            .memoryCache(LruCache(mem))
+            .memoryCache(LruCache(maximumMemorySizeForLruCache))
             .build()
         Picasso.setSingletonInstance(picasso)
 


### PR DESCRIPTION
[Jira Ticket](https://jira.taboola.com/browse/MOB-984)

The behavior happens since Picasso is loading the images constantly and not having enough memory in cache.

Also created a single instance of Picasso to be used inside the application

https://user-images.githubusercontent.com/106066986/183424385-e6c0aee8-589b-409e-b029-2e5a1c753056.mov


