### PR TITLE
Move fetchContent Call To Be From onHomePageStatusChange

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'androidx.core:core-splashscreen:1.0.0-rc01'
     implementation 'com.squareup.picasso:picasso:2.8'
     //Taboola SDK
-    implementation 'com.taboola:android-sdk:3.8.7'
+    implementation 'com.taboola:android-sdk:3.8.8'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/java/com/taboola/hp4udemoapplication/view/HomePageScreenFragment.kt
+++ b/app/src/main/java/com/taboola/hp4udemoapplication/view/HomePageScreenFragment.kt
@@ -41,13 +41,13 @@ class HomePageScreenFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val tblHomePageSettings: TBLHomePageSettings?  =
+        val tblHomePageSettings: TBLHomePageSettings =
             TBLHomePageSettings.TBLHomePageSettingsBuilder(
-                HP4UDemoConstants.HOME_PAGE_SOURCE_TYPE,
                 HP4UDemoConstants.HOME_PAGE_PAGE_URL,
                 HP4UDemoConstants.SECTION_1_NAME,
                 HP4UDemoConstants.SECTION_2_NAME,
-                HP4UDemoConstants.SECTION_3_NAME).build()
+                HP4UDemoConstants.SECTION_3_NAME).build() ?: return
+
         homePage = Taboola.getHomePage(
             tblHomePageSettings,
             object : TBLHomePageListener() {
@@ -64,10 +64,16 @@ class HomePageScreenFragment : Fragment() {
                     )
                     return false
                 }
+
+                override fun onHomePageStatusChanged(status: Boolean) {
+                    if (status) {
+                        homePage?.fetchContent()
+                    }
+                }
             }
         )
 
-        homePage?.fetchContent()
+
         homePage?.attach(binding.homepageRecyclerview)
         val homePageAdapter =
             HomePageAdapter(homePage, object : HomePageItemClickListener {


### PR DESCRIPTION
[Jira Ticket](https://jira.taboola.com/browse/MOB-1452)

<img width="944" alt="Screen Shot 2022-11-20 at 17 16 49" src="https://user-images.githubusercontent.com/106066986/202983854-96243d4e-f8fd-495b-8e2c-a5001dd1ed9f.png">

Also upgraded to latest Taboola SDK version 3.8.8