### PR TITLE
FetchContent raceCondition 

### DIFF
--- a/app/src/main/java/com/taboola/hp4udemoapplication/view/HomePageScreenFragment.kt
+++ b/app/src/main/java/com/taboola/hp4udemoapplication/view/HomePageScreenFragment.kt
@@ -64,15 +64,10 @@ class HomePageScreenFragment : Fragment() {
                     )
                     return false
                 }
-
-                override fun onHomePageStatusChanged(status: Boolean) {
-                    if (status) {
-                        homePage?.fetchContent()
-                    }
-                }
             }
         )
-
+        
+        homePage?.fetchContent()
 
         homePage?.attach(binding.homepageRecyclerview)
         val homePageAdapter =


### PR DESCRIPTION
Reverting code that called fetchContent only after getting the home page status callback (this was fixed in 3.8.10).