### PR TITLE
feature/upgrade-to-version-3.8.13

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     implementation 'androidx.core:core-splashscreen:1.0.0-rc01'
     implementation 'com.squareup.picasso:picasso:2.8'
     //Taboola SDK
-    implementation 'com.taboola:android-sdk:3.8.8'
+    implementation 'com.taboola:android-sdk:3.8.13'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'


### PR DESCRIPTION
Upgrading taboola sdk to latest version (3.8.13)